### PR TITLE
Update to PyChromecast 12.1.4 and paho-mqtt 1.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-paho-mqtt==1.5.0
-PyChromecast==5.2.0
+paho-mqtt==1.6.1
+PyChromecast==12.1.4


### PR DESCRIPTION
I had problems getting the outdated dependencies working on a recent Alpine Linux 3.16 (python 3.10.5) on aarch64 so I updated them which then also required a compatiblity patch from @rickynils to get it working.

Tested with a Canton Soundbar 10 (Chromecast built-in)

Thanks a lot for this project - it really works like a charm!

```
DEBUG:__main__:~ reading config
INFO:config:config file path: /root/dev/chromecast-mqtt-connector/config.ini
INFO:config:config file has been found
DEBUG:__main__:~ connecting to mqtt
DEBUG:__main__:~ starting chromecast discovery
DEBUG:discovery:starting discovery
DEBUG:mqtt:connected to mqtt with result code 0
DEBUG:event:mqtt connected callback has been invoked
DEBUG:__main__:~ initialization finished
DEBUG:mqtt:subscribing to topic chromecast/+/command/volume_level
DEBUG:mqtt:subscribing to topic chromecast/+/command/volume_muted
DEBUG:mqtt:subscribing to topic chromecast/+/command/player_position
DEBUG:mqtt:subscribing to topic chromecast/+/command/player_state
DEBUG:event:mqtt topics have been subscribed
DEBUG:asyncio:Using selector: EpollSelector
/usr/lib/python3.10/site-packages/zeroconf/_services/browser.py:168: FutureWarning: <ChromecastDiscovery(Thread-3, started 281473704172320)> has no update_service method. Provide one (it can be empty if you don't care about the updates), it'll become mandatory.
  warnings.warn(
INFO:discovery:adding chromecast with name "Smart-Soundbar-10-54edc558152c874ed7be9b9fa03f01c3._googlecast._tcp.local."
INFO:discovery:chromecast device name "Soundbar 10"
INFO:event:added device Soundbar 10
DEBUG:mqtt:sending topic chromecast/Soundbar 10/connection_status with value "WAITING"
DEBUG:asyncio:Using selector: EpollSelector
DEBUG:pychromecast.discovery:HostBrowser thread started
DEBUG:pychromecast.discovery:add_service _googlecast._tcp.local., Smart-Soundbar-10-54edc558152c874ed7be9b9fa03f01c3._googlecast._tcp.local.
DEBUG:pychromecast.discovery:Addded host 10.8.4.15
DEBUG:pychromecast:Found chromecast Soundbar 10 (54edc558-152c-874e-d7be-9b9fa03f01c3)
DEBUG:pychromecast:get_chromecast_from_cast_info CastInfo(services={ServiceInfo(type='mdns', data='Smart-Soundbar-10-54edc558152c874ed7be9b9fa03f01c3._googlecast._tcp.local.')}, uuid=UUID('54edc558-152c-874e-d7be-9b9fa03f01c3'), model_name='Smart Soundbar 10', friendly_name='Soundbar 10', host='10.8.4.15', port=8009, cast_type=None, manufacturer=None)
DEBUG:pychromecast.dial:get_info_from_service resolved service ServiceInfo(type='mdns', data='Smart-Soundbar-10-54edc558152c874ed7be9b9fa03f01c3._googlecast._tcp.local.') to service_info ServiceInfo(type='_googlecast._tcp.local.', name='Smart-Soundbar-10-54edc558152c874ed7be9b9fa03f01c3._googlecast._tcp.local.', addresses=[b'\n\x08\x04\x0f'], port=8009, weight=0, priority=0, server='54edc558-152c-874e-d7be-9b9fa03f01c3.local.', properties={b'id': b'54edc558152c874ed7be9b9fa03f01c3', b'cd': b'3D1822E0547755BDC81635126C78533B', b'rm': b'', b've': b'05', b'md': b'Smart Soundbar 10', b'ic': b'/setup/icon.png', b'fn': b'Soundbar 10', b'ca': b'198660', b'st': b'0', b'bs': b'FA8FCA5E0F6F', b'nf': b'1', b'rs': b''}, interface_index=None)
DEBUG:pychromecast.dial:Resolved service ServiceInfo(type='mdns', data='Smart-Soundbar-10-54edc558152c874ed7be9b9fa03f01c3._googlecast._tcp.local.') to 10.8.4.15
DEBUG:pychromecast.dial:cast type: audio, manufacturer: Canton Elektronik GmbH + Co. KG
DEBUG:pychromecast.dial:get_info_from_service resolved service ServiceInfo(type='mdns', data='Smart-Soundbar-10-54edc558152c874ed7be9b9fa03f01c3._googlecast._tcp.local.') to service_info ServiceInfo(type='_googlecast._tcp.local.', name='Smart-Soundbar-10-54edc558152c874ed7be9b9fa03f01c3._googlecast._tcp.local.', addresses=[b'\n\x08\x04\x0f'], port=8009, weight=0, priority=0, server='54edc558-152c-874e-d7be-9b9fa03f01c3.local.', properties={b'id': b'54edc558152c874ed7be9b9fa03f01c3', b'cd': b'3D1822E0547755BDC81635126C78533B', b'rm': b'', b've': b'05', b'md': b'Smart Soundbar 10', b'ic': b'/setup/icon.png', b'fn': b'Soundbar 10', b'ca': b'198660', b'st': b'0', b'bs': b'FA8FCA5E0F6F', b'nf': b'1', b'rs': b''}, interface_index=None)
DEBUG:pychromecast.controllers:Receiver:Updating status
DEBUG:pychromecast.controllers:Received status: CastStatus(is_active_input=None, is_stand_by=None, volume_level=0.07999999821186066, volume_muted=False, app_id=None, display_name=None, namespaces=[], session_id=None, transport_id=None, status_text='', icon_url=None, volume_control_type='master')
INFO:chromecast:connected to chromecast Soundbar 10
DEBUG:chromecast:command CreateConnectionCommand(device_name='Soundbar 10') finished
```