### PR TITLE
Implement queue functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,31 @@ Change volume using values from `0` to `100`:
 Change mute state: publish `0` or `1` to `chromecast/friendly_name/command/volume_muted`.
 
 
-Play something: Publish a json array with two elements (content url and content type) to
-`chromecast/friendly_name/command/player_state`, e.g. `["http://your.stream.url.here", "audio/mpeg"]`.
-You can also just publish a URL to `player_state` (just as string, not as json array, e.g.
+Play something: Publish a URL to `player_state` (just as string, not as json array, e.g.
 `http://your.stream.url.here`), the application then tries to guess the required MIME type.
+
+Or you can publish a json array with two elements (content url and content type) to
+`chromecast/friendly_name/command/player_state`, e.g. `["http://your.stream.url.here", "audio/mpeg"]`.
+
+Or you can publish a json object with any of the following properties, e.g.
+`{"url": "http://http://your.stream.url.here", "content_type": "audio/mpeg", "enqueue": false}`.
+
+Known properties from pychromecast BaseMediaPlayer.play_media() function:
+```
+"url": "http://http://your.stream.url.here"
+"content_type": "audio/mpeg"
+"title": null
+"thumb": null
+"current_time": null
+"autoplay": true
+"stream_type": "BUFFERED"
+"metadata": null
+"subtitles": null
+"subtitles_lang": "en-US"
+"subtitles_mime": "text/vtt"
+"subtitle_id": 1
+"enqueue": false
+```
 
 For other player controls, simply publish e.g. `RESUME`, `PAUSE`, `STOP`, `SKIP` or `REWIND` to
 `chromecast/friendly_name/command/player_state`. Attention: This is case-sensitive!

--- a/README.md
+++ b/README.md
@@ -80,5 +80,5 @@ Known properties from pychromecast BaseMediaPlayer.play_media() function:
 "enqueue": false
 ```
 
-For other player controls, simply publish e.g. `RESUME`, `PAUSE`, `STOP`, `SKIP` or `REWIND` to
-`chromecast/friendly_name/command/player_state`. Attention: This is case-sensitive!
+For other player controls, simply publish e.g. `RESUME`, `PAUSE`, `STOP`, `SKIP`, `REWIND`,
+`PREV` or `NEXT` to `chromecast/friendly_name/command/player_state`. Attention: This is case-sensitive!

--- a/handler/adapter.py
+++ b/handler/adapter.py
@@ -26,6 +26,8 @@ PlayerResumeCommand = namedtuple("PlayerResumeCommand", [])
 PlayerStopCommand = namedtuple("PlayerStopCommand", [])
 PlayerSkipCommand = namedtuple("PlayerSkipCommand", [])
 PlayerRewindCommand = namedtuple("PlayerRewindCommand", [])
+PlayerPreviousCommand = namedtuple("PlayerPreviousCommand", [])
+PlayerNextCommand = namedtuple("PlayerNextCommand", [])
 
 CastReceivedStatus = namedtuple("CastReceivedStatus", ["status"])
 CastConnectionStatus = namedtuple("CastConnectionStatus", ["status"])
@@ -153,6 +155,12 @@ class ChromecastConnection(MqttChangesCallback):
     def on_player_rewind_requested(self):
         self.processing_queue.put(PlayerRewindCommand())
 
+    def on_player_previous_requested(self):
+        self.processing_queue.put(PlayerPreviousCommand())
+
+    def on_player_next_requested(self):
+        self.processing_queue.put(PlayerNextCommand())
+
     def _worker(self):
         while True:
             # TODO we should actually only get commands from the command queue if we are connected
@@ -198,6 +206,10 @@ class ChromecastConnection(MqttChangesCallback):
                     self._worker_player_skip()
                 elif isinstance(item, PlayerRewindCommand):
                     self._worker_player_rewind()
+                elif isinstance(item, PlayerPreviousCommand):
+                    self._worker_player_previous()
+                elif isinstance(item, PlayerNextCommand):
+                    self._worker_player_next()
                 elif isinstance(item, CastReceivedStatus):
                     self._worker_cast_received_status(item.status)
                 elif isinstance(item, CastConnectionStatus):
@@ -331,6 +343,16 @@ class ChromecastConnection(MqttChangesCallback):
         self.logger.info("rewind request")
 
         self.device.media_controller.rewind()
+
+    def _worker_player_previous(self):
+        self.logger.info("previous request")
+
+        self.device.media_controller.queue_prev()
+
+    def _worker_player_next(self):
+        self.logger.info("next request")
+
+        self.device.media_controller.queue_next()
 
     # ##################################################################################
 

--- a/handler/adapter.py
+++ b/handler/adapter.py
@@ -20,7 +20,7 @@ VolumeMuteCommand = namedtuple("VolumeMuteCommand", ["muted"])
 VolumeLevelRelativeCommand = namedtuple("VolumeLevelRelativeCommand", ["value"])
 VolumeLevelAbsoluteCommand = namedtuple("VolumeLevelAbsoluteCommand", ["value"])
 PlayerPositionCommand = namedtuple("PlayerPositionCommand", ["position"])
-PlayerPlayStreamCommand = namedtuple("PlayerPlayStreamCommand", ["content_url", "content_type"])
+PlayerPlayStreamCommand = namedtuple("PlayerPlayStreamCommand", ["url", "content_type", "title", "thumb", "current_time", "autoplay", "stream_type", "metadata", "subtitles", "subtitles_lang", "subtitles_mime", "subtitle_id", "enqueue"])
 PlayerPauseCommand = namedtuple("PlayerPauseCommand", [])
 PlayerResumeCommand = namedtuple("PlayerResumeCommand", [])
 PlayerStopCommand = namedtuple("PlayerStopCommand", [])
@@ -135,8 +135,8 @@ class ChromecastConnection(MqttChangesCallback):
     def on_player_position_requested(self, position):
         self.processing_queue.put(PlayerPositionCommand(position))
 
-    def on_player_play_stream_requested(self, content_url, content_type):
-        self.processing_queue.put(PlayerPlayStreamCommand(content_url, content_type))
+    def on_player_play_stream_requested(self, url, content_type, title=None, thumb=None, current_time=None, autoplay=True, stream_type="BUFFERED", metadata=None, subtitles=None, subtitles_lang="en-US", subtitles_mime="text/vtt", subtitle_id=1, enqueue=False):
+        self.processing_queue.put(PlayerPlayStreamCommand(url, content_type, title, thumb, current_time, autoplay, stream_type, metadata, subtitles, subtitles_lang, subtitles_mime, subtitle_id, enqueue))
 
     def on_player_pause_requested(self):
         self.processing_queue.put(PlayerPauseCommand())
@@ -187,7 +187,7 @@ class ChromecastConnection(MqttChangesCallback):
                 elif isinstance(item, PlayerPositionCommand):
                     self._worker_player_position(item.position)
                 elif isinstance(item, PlayerPlayStreamCommand):
-                    self._worker_player_play_stream(item.content_url, item.content_type)
+                    self._worker_player_play_stream(item)
                 elif isinstance(item, PlayerPauseCommand):
                     self._worker_player_pause()
                 elif isinstance(item, PlayerResumeCommand):
@@ -302,10 +302,10 @@ class ChromecastConnection(MqttChangesCallback):
 
         self.device.media_controller.seek(position)
 
-    def _worker_player_play_stream(self, content_url, content_type):
-        self.logger.info("play stream request, url = %s, type = %s" % (content_url, content_type))
+    def _worker_player_play_stream(self, stream):
+        self.logger.info("play stream request, url = %s, content_type = %s" % (stream.url, stream.content_type))
 
-        self.device.media_controller.play_media(content_url, content_type, autoplay=True)
+        self.device.media_controller.play_media(url=stream.url, content_type=stream.content_type, title=stream.title, thumb=stream.thumb, current_time=stream.current_time, autoplay=stream.autoplay, stream_type=stream.stream_type, metadata=stream.metadata, subtitles=stream.subtitles, subtitles_lang=stream.subtitles_lang, subtitles_mime=stream.subtitles_mime, subtitle_id=stream.subtitle_id, enqueue=stream.enqueue)
 
     def _worker_player_pause(self):
         self.logger.info("pause request")

--- a/handler/properties.py
+++ b/handler/properties.py
@@ -32,6 +32,8 @@ STATE_REQUEST_PAUSE = "PAUSE"
 STATE_REQUEST_STOP = "STOP"
 STATE_REQUEST_SKIP = "SKIP"
 STATE_REQUEST_REWIND = "REWIND"
+STATE_REQUEST_PREV = "PREV"
+STATE_REQUEST_NEXT = "NEXT"
 
 
 # play stream has another syntax, not listed here therefore
@@ -66,6 +68,12 @@ class MqttChangesCallback:
         pass
 
     def on_player_rewind_requested(self):
+        pass
+
+    def on_player_prev_requested(self):
+        pass
+
+    def on_player_next_requested(self):
         pass
 
 
@@ -217,6 +225,10 @@ class MqttPropertyHandler:
             self.changes_callback.on_player_skip_requested()
         elif payload == STATE_REQUEST_REWIND:
             self.changes_callback.on_player_rewind_requested()
+        elif payload == STATE_REQUEST_PREV:
+            self.changes_callback.on_player_previous_requested()
+        elif payload == STATE_REQUEST_NEXT:
+            self.changes_callback.on_player_next_requested()
         else:
             if len(payload) == 0:
                 return


### PR DESCRIPTION
I've implemented Queue functionality which allows to add URLs without autoplay and navigate in the queue with PREV / NEXT commands.

To properly implement this I also decided to introduces json object format for player_state to be able to set all available parameters that pychromecast BaseMediaPlayer.play_media() supports but json array and text format are still available so it's fully backwards compatible. This also allows to set "title" which is useful to me because the chromecast uses it in the next media status update.

Changes were tested with a Chromecast Audio and work fine for me. It seems there is no possibility to queue stuff when the chromecast is currently stopped and then start playing it. Resume does not seem to work in this case.  But if the chromecast is currently playing it works fine to add additional stuff to the queue and then use NEXT / PREV to navigate in the queue. 

Grüße aus Andritz.