### PR TITLE
Publish model name and address on MQTT when device appears

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ to each Chromecast.
 ```
 # - read only
 chromecast/friendly_name/friendly_name
+chromecast/friendly_name/model_name
+chromecast/friendly_name/address
 chromecast/friendly_name/connection_status
 chromecast/friendly_name/cast_type
 chromecast/friendly_name/current_app

--- a/handler/properties.py
+++ b/handler/properties.py
@@ -4,6 +4,8 @@ import mimetypes
 
 # only used for publishing
 TOPIC_FRIENDLY_NAME = "chromecast/%s/friendly_name"
+TOPIC_MODEL_NAME = "chromecast/%s/model_name"
+TOPIC_ADDRESS = "chromecast/%s/address"
 TOPIC_CONNECTION_STATUS = "chromecast/%s/connection_status"
 TOPIC_CAST_TYPE = "chromecast/%s/cast_type"
 TOPIC_CURRENT_APP = "chromecast/%s/current_app"
@@ -142,6 +144,11 @@ class MqttPropertyHandler:
         self._write(TOPIC_MEDIA_IMAGES, images)
         self._write(TOPIC_MEDIA_CONTENT_TYPE, content_type)
         self._write(TOPIC_MEDIA_CONTENT_URL, content_id)
+
+    def write_connection_info(self, device_name, model_name, ip_address, port):
+        self._write(TOPIC_FRIENDLY_NAME, device_name)
+        self._write(TOPIC_MODEL_NAME, model_name)
+        self._write(TOPIC_ADDRESS, "%s:%d" % (ip_address, port))
 
     def write_connection_status(self, status):
         self._write(TOPIC_CONNECTION_STATUS, status)

--- a/helper/discovery.py
+++ b/helper/discovery.py
@@ -68,7 +68,6 @@ class ChromecastDiscovery(Thread):
 
     def add_service(self, zconf, typ, name):
         """ Add a service to the collection. """
-
         # easy filtering
         if not name.endswith(GOOGLE_CAST_IDENTIFIER):
             return
@@ -89,8 +88,7 @@ class ChromecastDiscovery(Thread):
             self.logger.warn("services not discovered for device")
             return
 
-        ips = zconf.cache.entries_with_name(service.server.lower())
-        host = repr(ips[0]) if ips else service.server
+        address = service.parsed_scoped_addresses()[0]
 
         def get_value(key):
             value = service.properties.get(key.encode('utf-8'))
@@ -102,4 +100,4 @@ class ChromecastDiscovery(Thread):
         self.logger.info("chromecast device name \"%s\"" % device_name)
 
         self.services[name] = device_name
-        self.discovery_callback.on_chromecast_appeared(device_name, model_name, host, service.port)
+        self.discovery_callback.on_chromecast_appeared(device_name, model_name, address, service.port)


### PR DESCRIPTION
As can be seen in `discovery.py:105` the data for model name, host and IP was actually already there but wasn't used up to now. This commit fixes `add_service()` to actually pass a host not some service struct and sends the data to MQTT when a device appears.

This introduces two new MQTT topics:
```
chromecast/<devicename>/model_name
chromecast/<devicename>/address
```

Right now the data on MQTT looks like this:
```
chromecast/Soundbar 10/connection_status CONNECTED
chromecast/Soundbar 10/volume_level 14
chromecast/Soundbar 10/volume_muted 0
chromecast/Soundbar 10/player_state IDLE
chromecast/Soundbar 10/cast_type audio
chromecast/Soundbar 10/friendly_name Soundbar 10
chromecast/Soundbar 10/model_name Smart Soundbar 10
chromecast/Soundbar 10/address 10.8.4.15:8009
chromecast/Wohnzimmer/connection_status CONNECTED
chromecast/Wohnzimmer/volume_level 14
chromecast/Wohnzimmer/volume_muted 0
chromecast/Wohnzimmer/player_state IDLE
chromecast/Wohnzimmer/cast_type group
chromecast/Wohnzimmer/friendly_name Wohnzimmer
chromecast/Wohnzimmer/model_name Google Cast Group
chromecast/Wohnzimmer/address 10.8.4.15:32041
```

