### PR TITLE
Update paho-mqtt and PyChromecast dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Provides status information and control capabilities of your Chromecast devices 
 
 ## Installation requirements
 
-* Python 3.6+
+* Python 3.7+
 * pychromecast
 * paho-mqtt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-paho-mqtt==1.6.1
+paho-mqtt==2.0.0
 PyChromecast==13.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 paho-mqtt==1.6.1
-PyChromecast==12.1.4
+PyChromecast==13.1.0


### PR DESCRIPTION
- PyChromecast update to latest 13.x was painless
- paho-mqtt update changed to new callback API v2 but the migration guide was very helpful
https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html
- paho-mqtt now needs at least python 3.7 so also bump it in the README

I've tested the changes for about a week in my environment and it works like a charm.

I did not update PyChromecast to 14.0 yet because it requires Python 3.11 and has some breaking changes which will affect us. It feels like it's too early for that.